### PR TITLE
feat(autoware.repos): update tier4/glog to v0.7.0

### DIFF
--- a/testing.repos
+++ b/testing.repos
@@ -82,7 +82,7 @@ repositories:
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git
-    version: v0.6.0
+    version: v0.7.0
   # launcher
   launcher/autoware_launch:
     type: git


### PR DESCRIPTION
This PR updates the version of the repository tier4/glog in autoware.repos